### PR TITLE
Update jdom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 			<groupId>org.jdom</groupId>
 			<artifactId>jdom</artifactId>
 			<!-- <version>[1.1,2.0)</version> -->
-			<version>1.1</version>
+			<version>2.0.6</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Fixes Dependabot security alert. Looks like 2.0.6 is current latest stable.

Ping @semmerson @oxelson 